### PR TITLE
Added non-dependent task ordering via mustRunAfter to enable complex wor...

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,23 @@ var items = {
     name: 'd',
     dep: ['c']
   },
+  e: {
+    name: 'e',
+    // mustRunAfter defines a non-dependent task-ordering
+    // e will always run after d, but d will not
+    // automatically run just because e is run.
+    mustRunAfter: ['d']
+  }
 };
 
-var names = ['d', 'b', 'c', 'a']; // The names of the items you want arranged, need not be all
+var names = ['d', 'e', 'b', 'c', 'a']; // The names of the items you want arranged, need not be all
 
 var results = [];
 
 sequencify(items, names, results);
 
 console.log(results);
-// ['a','b','c','d'];
+// ['a','b','c','d','e'];
 ```
 
 LICENSE

--- a/index.js
+++ b/index.js
@@ -2,25 +2,15 @@
 
 "use strict";
 
-var sequence = function (tasks, names, results, nest) {
+var sequence = function (tasks, names, results, nest, allRunningTasks) {
 	var i, name, node, e, j;
 	nest = nest || [];
+	allRunningTasks = allRunningTasks || collectAllRunningTasks(tasks, names);
 	for (i = 0; i < names.length; i++) {
 		name = names[i];
 		// de-dup results
 		if (results.indexOf(name) === -1) {
 			node = tasks[name];
-			if (!node) {
-				e = new Error('task "'+name+'" is not defined');
-				e.missingTask = name;
-				e.taskList = [];
-				for (j in tasks) {
-					if (tasks.hasOwnProperty(j)) {
-						e.taskList.push(tasks[j].name);
-					}
-				}
-				throw e;
-			}
 			if (nest.indexOf(name) > -1) {
 				nest.push(name);
 				e = new Error('Recursive dependencies detected: '+nest.join(' -> '));
@@ -35,12 +25,49 @@ var sequence = function (tasks, names, results, nest) {
 			}
 			if (node.dep.length) {
 				nest.push(name);
-				sequence(tasks, node.dep, results, nest); // recurse
+				sequence(tasks, node.dep, results, nest, allRunningTasks); // recurse
+				nest.pop(name);
+			}
+			if (node.mustRunAfter && node.mustRunAfter.length) {
+				nest.push(name);
+				// sequence all mustRunAfter tasks that are going to be run
+				sequence(tasks, node.mustRunAfter.filter(allRunningTasks.hasOwnProperty.bind(allRunningTasks)), results, nest, allRunningTasks); // recurse
 				nest.pop(name);
 			}
 			results.push(name);
 		}
 	}
+};
+
+// Simply collects all tasks that need to be run as a hashmap of map[taskname] = true
+var collectAllRunningTasks = function(tasks, names, allRunningTasks) {
+	var i, name, node, e, j;
+	allRunningTasks = allRunningTasks || {};
+	for (i = 0; i < names.length; i++) {
+		name = names[i];
+		// de-dup results
+		if (!allRunningTasks[name]) {
+			node = tasks[name];
+			if (!node) {
+				e = new Error('task "'+name+'" is not defined');
+				e.missingTask = name;
+				e.taskList = [];
+				for (j in tasks) {
+					if (tasks.hasOwnProperty(j)) {
+						e.taskList.push(tasks[j].name);
+					}
+				}
+				throw e;
+			}
+			// order does not matter at this stage, so go ahead and store
+			// the requested name
+			allRunningTasks[name] = true;
+			if (node.dep.length) {
+				collectAllRunningTasks(tasks, node.dep, allRunningTasks); // recurse
+			}
+		}
+	}
+	return allRunningTasks;
 };
 
 module.exports = sequence;


### PR DESCRIPTION
...kflows.

These changes enable a `mustRunAfter` property which allows for non-dependent ordered task workflows.

The only way I could see to make it work is two recursive passes over the list:
1. The first pass creates a hashmap recording all tasks and task dependencies that must be run.  It handles the error in the case where a task does not exist.  It should be relatively fast.
2. The second pass runs like the original recursive process, but with an additional recursion into any tasks within `mustRunAfter` that exist within the results of the first pass.

This shouldn't be much slower, and I included extra tests to verify it.  I left a gap in the test tree at `h` so as to not change the test for a non-existent task, but that may be suboptimal.

This is a possible first step in fixing robrich/orchestrator#15 and OverZealous/run-sequence#1
